### PR TITLE
Use postCopy instead of postBuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ import Codec.SelfExtract.Distribution (bundle)
 import Distribution.Simple
 
 main = defaultMainWithHooks simpleUserHooks
-  { postBuild = \args bf pd lbi -> do
-      postBuild simpleUserHooks args bf pd lbi
+  { postCopy = \args cf pd lbi -> do
+      postCopy simpleUserHooks args cf pd lbi
       bundle "name-of-executable" "dir-to-bundle" lbi
   }
 ```
@@ -44,8 +44,8 @@ import Distribution.Simple
 import Path (reldir)
 
 main = defaultMainWithHooks simpleUserHooks
-  { postBuild = \args bf pd lbi -> do
-      postBuild simpleUserHooks args bf pd lbi
+  { postCopy = \args cf pd lbi -> do
+      postCopy simpleUserHooks args cf pd lbi
       bundle' "name-of-executable" [reldir|dir-to-bundle|] lbi
   }
 ```

--- a/example/basic/Setup.hs
+++ b/example/basic/Setup.hs
@@ -2,7 +2,7 @@ import Codec.SelfExtract.Distribution (bundle)
 import Distribution.Simple
 
 main = defaultMainWithHooks simpleUserHooks
-  { postBuild = \args bf pd lbi -> do
-      postBuild simpleUserHooks args bf pd lbi
+  { postCopy = \args flags pd lbi -> do
+      postCopy simpleUserHooks args flags pd lbi
       bundle "self-extract-basic" "dist" lbi
   }

--- a/src/Codec/SelfExtract/Distribution.hs
+++ b/src/Codec/SelfExtract/Distribution.hs
@@ -12,10 +12,23 @@ import Data.Binary (Word32, encode)
 import Data.ByteString as BS
 import Data.ByteString.Lazy as LBS
 import Data.FileEmbed (injectFileWith)
-import Distribution.Simple.LocalBuildInfo (LocalBuildInfo(..))
-import Path (Dir, File, Path, fromAbsFile, parseRelDir, parseRelFile, relfile, toFilePath, (</>))
+import Distribution.Simple.LocalBuildInfo (InstallDirs(..), LocalBuildInfo(..), fromPathTemplate)
+import Distribution.Simple.Setup (ConfigFlags(..), fromFlag)
+import Path
+    ( Abs
+    , Dir
+    , File
+    , Path
+    , fromAbsFile
+    , parseAbsDir
+    , parseRelDir
+    , parseRelFile
+    , relfile
+    , toFilePath
+    , (</>)
+    )
 import Path.IO (doesFileExist, renameFile, resolveDir', withSystemTempDir)
-import System.PosixCompat.Files (fileSize, getFileStatus)
+import qualified System.PosixCompat.Files as Posix
 
 import Codec.SelfExtract.Tar (tar)
 
@@ -31,12 +44,8 @@ bundle exe dir lbi = do
 --
 -- To be used as part of the Setup.hs file.
 bundle' :: String -> Path b Dir -> LocalBuildInfo -> IO ()
-bundle' exeName dir LocalBuildInfo{buildDir} = do
-  exeDir <- resolveDir' buildDir
-  exeNameDir <- parseRelDir exeName
-  exeNameFile <- parseRelFile exeName
-
-  let exe = exeDir </> exeNameDir </> exeNameFile
+bundle' exeName dir lbi = do
+  exe <- getExe lbi exeName
   unlessM (doesFileExist exe) $ error $ "Executable does not exist: " ++ exeName
 
   size <- getFileSize exe
@@ -56,11 +65,23 @@ bundle' exeName dir LocalBuildInfo{buildDir} = do
 
     renameFile combined exe
 
+  Posix.setFileMode (fromAbsFile exe) executeMode
+  where
+    -- 755 permissions
+    executeMode = Posix.unionFileModes Posix.stdFileMode Posix.ownerExecuteMode
+
+-- | Get the executable to be made self-extracting.
+getExe :: LocalBuildInfo -> String -> IO (Path Abs File)
+getExe LocalBuildInfo{configFlags} exeName = do
+  binDir <- parseAbsDir $ fromPathTemplate $ fromFlag $ bindir $ configInstallDirs configFlags
+  exe <- parseRelFile exeName
+  return $ binDir </> exe
+
 -- | Get the size of the given file.
 getFileSize :: Path b File -> IO Word32
-getFileSize = fmap getSize . getFileStatus . toFilePath
+getFileSize = fmap getSize . Posix.getFileStatus . toFilePath
   where
-    getSize = fromIntegral . fileSize
+    getSize = fromIntegral . Posix.fileSize
 
 -- | Concatenate the given files and write to the given file.
 cat :: [Path b File] -> Path b File -> IO ()


### PR DESCRIPTION
:sparkles: _**This is an old work account. Please reference @brandonchinn178 for all future communication**_ :sparkles:
<!-- updated by mention_personal_account_in_comments.py -->

---

There were errors with `strip` when bundling in the postBuild step.

Other fixes:
* make bundled file executable (don't know why this didn't break before)
* qualify the `Posix` import