### PR TITLE
Make bundle occur in same directory as the exe

### DIFF
--- a/src/Codec/SelfExtract.hs
+++ b/src/Codec/SelfExtract.hs
@@ -34,13 +34,21 @@ import Path
     , Path
     , fromAbsDir
     , fromAbsFile
+    , parent
     , parseAbsFile
     , relfile
     , toFilePath
     , (</>)
     )
 import Path.IO
-    (doesFileExist, renameFile, resolveDir', resolveFile', withSystemTempDir, withSystemTempFile)
+    ( doesFileExist
+    , renameFile
+    , resolveDir'
+    , resolveFile'
+    , withSystemTempDir
+    , withSystemTempFile
+    , withTempDir
+    )
 import System.Environment (getExecutablePath)
 import System.IO (IOMode(..), SeekMode(..), hClose, hSeek, withFile)
 import qualified System.PosixCompat.Files as Posix
@@ -107,7 +115,7 @@ bundle' exe dir = do
 
   size <- getFileSize exe
 
-  withSystemTempDir "self-extract" $ \tempDir -> do
+  withTempDir (parent exe) "self-extract" $ \tempDir -> do
     let exeWithSize = tempDir </> [relfile|exe_with_size|]
     injectFileWith "self-extract"
       (LBS.toStrict $ encode size)


### PR DESCRIPTION
:sparkles: _**This is an old work account. Please reference @brandonchinn178 for all future communication**_ :sparkles:
<!-- updated by mention_personal_account_in_comments.py -->

---

This prevents cross-device link errors when calling `renameFile` at the end, if `.stack-work` and `/tmp` are on different physical devices.